### PR TITLE
Add caching, network handler improvements, and performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# Project exclude paths
 /target/
-.idea/compiler.xml
-.idea/discord.xml
-.idea/jarRepositories.xml
-.idea/misc.xml
-.idea/vcs.xml
-.idea/artifacts/Expansion_localtime.xml
-out/artifacts/Expansion_localtime/Expansion-localtime.jar
+.idea/**
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 # Project exclude paths
 /target/
+.idea/compiler.xml
+.idea/discord.xml
+.idea/jarRepositories.xml
+.idea/misc.xml
+.idea/vcs.xml
+.idea/artifacts/Expansion_localtime.xml
+out/artifacts/Expansion_localtime/Expansion-localtime.jar

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.aboodyy</groupId>
     <artifactId>localtime-expansion</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
 
     <repositories>
         <repository>

--- a/src/main/java/net/aboodyy/localtime/DateManager.java
+++ b/src/main/java/net/aboodyy/localtime/DateManager.java
@@ -20,7 +20,7 @@ public class DateManager implements Listener {
 
     private final Map<UUID, String> timezones;
     private final Map<String, String> cache;
-    private int retryDelay = 0;
+    private int retryDelay;
 
     DateManager() {
         this.timezones = new HashMap<>();
@@ -86,6 +86,14 @@ public class DateManager implements Listener {
                 if (timezone.equalsIgnoreCase("undefined")) {
                     Bukkit.getLogger().info(FAILED);
                     timezone = TimeZone.getDefault().getID();
+                    String finalTimezone = timezone;
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            timezones.put(player.getUniqueId(), finalTimezone);
+                        }
+                    }.runTaskLaterAsynchronously(PlaceholderAPIPlugin.getInstance(), retryDelay);
+                    return;
                 }
 
                 timezones.put(player.getUniqueId(), timezone);

--- a/src/main/java/net/aboodyy/localtime/DateManager.java
+++ b/src/main/java/net/aboodyy/localtime/DateManager.java
@@ -45,12 +45,11 @@ public class DateManager implements Listener {
     private final Cache<String, String> cache;
     private final ScheduledExecutorService executorService;
     private int retryDelay;
-    private final int cacheExpirationMinutes = 1440; // Cache entries expire after 1440 minutes (1 Day)
 
     public DateManager() {
         this.timezones = new ConcurrentHashMap<>();
         this.cache = CacheBuilder.newBuilder()
-                .expireAfterWrite(cacheExpirationMinutes, TimeUnit.MINUTES)
+                .expireAfterWrite(1, TimeUnit.DAYS)
                 .build();
         this.retryDelay = 5; // default to 5 seconds
         this.executorService = Executors.newSingleThreadScheduledExecutor();

--- a/src/main/java/net/aboodyy/localtime/DateManager.java
+++ b/src/main/java/net/aboodyy/localtime/DateManager.java
@@ -22,8 +22,7 @@ package net.aboodyy.localtime;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-
-import org.bukkit.Bukkit;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 
@@ -38,6 +37,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.*;
+import java.util.logging.Level;
 
 public class DateManager implements Listener {
 
@@ -82,7 +82,7 @@ public class DateManager implements Listener {
         timezone = TimeZone.getDefault().getID();
 
         if (address == null) {
-            Bukkit.getLogger().info(FAILED);
+            PlaceholderAPIPlugin.getInstance().getLogger().log(Level.WARNING, FAILED);
             cache.put(player.getUniqueId().toString(), timezone);
             return CompletableFuture.completedFuture(timezone);
         }
@@ -113,7 +113,7 @@ public class DateManager implements Listener {
                     }
                 } catch (Exception e) {
                     result = "undefined";
-                    Bukkit.getLogger().warning("[LocalTime] Exception while getting timezone for player " + player.getName() + ": " + e.getMessage());
+                    PlaceholderAPIPlugin.getInstance().getLogger().log(Level.WARNING, "[LocalTime] Exception while getting timezone for player " + player.getName() + ": " + e.getMessage(), e);
                     try {
                         Thread.sleep(retryDelay * 1000);
                     } catch (InterruptedException ignored) {}
@@ -121,7 +121,7 @@ public class DateManager implements Listener {
             }
 
             if (result.equalsIgnoreCase("undefined")) {
-                Bukkit.getLogger().info(FAILED);
+                PlaceholderAPIPlugin.getInstance().getLogger().log(Level.WARNING, FAILED);
                 result = timezoneFinal;
             }
 
@@ -130,7 +130,7 @@ public class DateManager implements Listener {
         }, executorService);
 
         futureTimezone.exceptionally(ex -> {
-            Bukkit.getLogger().warning("[LocalTime] Exception while getting timezone for player " + player.getName() + ": " + ex.getMessage());
+            PlaceholderAPIPlugin.getInstance().getLogger().log(Level.WARNING, "[LocalTime] Exception while getting timezone for player " + player.getName() + ": " + ex.getMessage(), ex);
             cache.put(player.getUniqueId().toString(), timezoneFinal);
             timezones.put(player.getUniqueId(), timezoneFinal);
             return timezoneFinal;

--- a/src/main/java/net/aboodyy/localtime/DateManager.java
+++ b/src/main/java/net/aboodyy/localtime/DateManager.java
@@ -1,23 +1,3 @@
-/*
-
-    LocalTime Expansion - Provides PlaceholderAPI placeholders to give player's local time
-    Copyright (C) 2020 aBooDyy
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
- */
-
 package net.aboodyy.localtime;
 
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
@@ -76,11 +56,19 @@ public class DateManager implements Listener {
                 try {
                     URL api = new URL("https://ipapi.co/" + address.getAddress().getHostAddress() + "/timezone/");
                     URLConnection connection = api.openConnection();
+                    connection.setConnectTimeout(5000);
+                    connection.setReadTimeout(5000);
 
                     BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-                    timezone = bufferedReader.readLine();
+                    String response = bufferedReader.readLine();
+                    if (response == null || response.isEmpty()) {
+                        timezone = "undefined";
+                    } else {
+                        timezone = response.trim();
+                    }
                 } catch (Exception e) {
                     timezone = "undefined";
+                    Bukkit.getLogger().warning("[LocalTime] Failed to retrieve timezone for " + player.getName() + " from ipapi.co: " + e.getMessage());
                 }
 
                 if (timezone.equalsIgnoreCase("undefined")) {

--- a/src/main/java/net/aboodyy/localtime/DateManager.java
+++ b/src/main/java/net/aboodyy/localtime/DateManager.java
@@ -1,3 +1,18 @@
+/*
+    LocalTime Expansion - Provides PlaceholderAPI placeholders to give player's local time
+    Copyright (C) 2020 aBooDyy
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package net.aboodyy.localtime;
 
 import org.bukkit.Bukkit;

--- a/src/main/java/net/aboodyy/localtime/LocalTimeExpansion.java
+++ b/src/main/java/net/aboodyy/localtime/LocalTimeExpansion.java
@@ -30,6 +30,7 @@ import org.bukkit.event.HandlerList;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings("unused")
 public class LocalTimeExpansion extends PlaceholderExpansion implements Cacheable, Configurable {
@@ -43,12 +44,12 @@ public class LocalTimeExpansion extends PlaceholderExpansion implements Cacheabl
 
     @Override
     public String getAuthor() {
-        return "aBooDyy";
+        return "aBooDyy, Opal";
     }
 
     @Override
     public String getVersion() {
-        return "1.2";
+        return "1.3";
     }
 
     @Override
@@ -82,7 +83,10 @@ public class LocalTimeExpansion extends PlaceholderExpansion implements Cacheabl
             args = identifier.split("time_");
             if (args.length < 2) return null;
 
-            return dateManager.getDate(args[1], dateManager.getTimeZone(p));
+            CompletableFuture<String> timezoneFuture = dateManager.getTimeZone(p);
+            String timezone = timezoneFuture.join();
+
+            return dateManager.getDate(args[1], timezone);
         }
 
         if (identifier.startsWith("timezone_")) {
@@ -99,8 +103,12 @@ public class LocalTimeExpansion extends PlaceholderExpansion implements Cacheabl
             return dateManager.getDate(format, args[1]);
         }
 
-        if (identifier.equalsIgnoreCase("time"))
-            return dateManager.getDate(format, dateManager.getTimeZone(p));
+        if (identifier.equalsIgnoreCase("time")) {
+            CompletableFuture<String> timezoneFuture = dateManager.getTimeZone(p);
+            String timezone = timezoneFuture.join();
+
+            return dateManager.getDate(format, timezone);
+        }
 
         return null;
     }

--- a/src/main/java/net/aboodyy/localtime/LocalTimeExpansion.java
+++ b/src/main/java/net/aboodyy/localtime/LocalTimeExpansion.java
@@ -70,6 +70,7 @@ public class LocalTimeExpansion extends PlaceholderExpansion implements Cacheabl
     public void clear() {
         dateManager.clear();
         HandlerList.unregisterAll(dateManager);
+        dateManager.shutdown();
     }
 
     @Override


### PR DESCRIPTION
Proposed changes reduce API calls by caching a players timezone for a determinate period of time (1 day) and similarly, local-time placeholders are much more consistent with a retryDelay being ran in the event that a players timezone is unable to be fetched due to API rate-limits. 

This should functionally mitigate a common occurrence of the expansion being "unable to fetch a players timezone" due to excessive API calls resulting in a rate-limit. The expansion has also been made to be completely thread-safe